### PR TITLE
Bug FIS-320 Header Component Storybook Iframe Size

### DIFF
--- a/src/hztl-foundation/src/stories/components/authorable/shared/site-structure/Header/Header.stories.tsx
+++ b/src/hztl-foundation/src/stories/components/authorable/shared/site-structure/Header/Header.stories.tsx
@@ -105,9 +105,11 @@ const meta: Meta<typeof Default> = {
   component: Default,
   decorators: [
     (Story) => (
-      <QueryClientProvider client={queryClient}>
-        <Story />
-      </QueryClientProvider>
+      <div className="min-h-80">
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </div>
     ),
   ],
   parameters: {


### PR DESCRIPTION
## What does this PR do and why?

This PR increases the size of the iframe that renders the Header component from within the corresponding Storybook docs page.

## Screenshots or screen recordings

| Before | After |
| ------ | ----- |
| <img width="1001" alt="Screenshot 2024-10-07 at 10 39 33 AM" src="https://github.com/user-attachments/assets/bf186c74-9683-4762-b0da-e6df7d685733"> | <img width="1001" alt="Screenshot 2024-10-07 at 10 39 05 AM" src="https://github.com/user-attachments/assets/b1fb939e-2fd1-42a2-8e93-a21986e2ce1d"> |

## How to set up and validate locally

1. Check out the branch _bug/FIS-320-header-story-iframe_
2. From a command prompt, navigate to _./src/hztl-foundation_ and execute `npm run storybook`.
3. Once Storybook loads, navigate to "Components / Authorable / Shared / Site Structure / Header / Docs" and observe the height of the rendered iframe.

## PR acceptance checklist

This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://docs.gitlab.com/ee/development/code_review.html#acceptance-checklist) for this PR.

<!-- template sourced from https://gitlab.com/gitlab-org/gitlab/-/blob/master/.gitlab/merge_request_templates/Default.md -->
