### PR TITLE
FIS-400: Updating the linkwrapper component to include a few addition…

### DIFF
--- a/src/hztl-foundation/src/helpers/SitecoreWrappers/LinkWrapper/LinkWrapper.tsx
+++ b/src/hztl-foundation/src/helpers/SitecoreWrappers/LinkWrapper/LinkWrapper.tsx
@@ -137,8 +137,35 @@ const LinkWrapper = forwardRef<HTMLAnchorElement, LinkWrapperProps>(
         </div>
       );
 
-    // If no content is present, don't print
-    if (!anchor && !href && !text) return <></>;
+    /*
+     *
+     * #1 | Link Text: Yes, Path URL: Yes (Link text and URL are defined)
+     * Expected Results: CTA should be visible on the front-end page
+     *
+     * #2 | Link Text: Yes, Path URL: No (Link text is defined, URL is empty)
+     * Expected Results: CTA should not be visible on the front-end page
+     * When the link is empty and the URL is set External, the href value is 'http://' (a Sitecore bug)
+     * (text && (!href || href === 'http://' || href === 'https://'))
+     *
+     * #3 | Link Text: No, Path URL: Yes (Internal link) (Link text is empty, URL is an internal link or a Sitecore item)
+     * Expected Results: CTA should display the Path text in the front-end
+     * Updated the title={title || text || href} and <span>{text || href}</span>
+     *
+     * #4 | Link Text: No, Path URL: Yes (External link) (Link text is empty, URL is an external link)
+     * Expected Results: CTA should display the Path text in the front-end without '/'
+     * Updated the <span>{text || (href?.startsWith('/') ? href.slice(1) : href)}</span>
+     *
+     * #5 | Link Text: Not, Path: Not (Link text is empty and URL is empty)
+     * Expected Results: CTA should not be visible on the front-end page
+     * if (!anchor && !href && !text) return <></>;
+     *
+     */
+    if (
+      (!anchor && !href && !text) ||
+      (text && (!href || href === 'http://' || href === 'https://')) // (a Sitecore bug when the External link is empty)
+    ) {
+      return <></>;
+    }
 
     return (
       <NextLink
@@ -149,9 +176,9 @@ const LinkWrapper = forwardRef<HTMLAnchorElement, LinkWrapperProps>(
         onClick={() => handleOnClick()}
         ref={ref}
         target={target}
-        title={title || text}
+        title={title || text || href}
       >
-        {text && <span>{text}</span>}
+        <span>{text || (href?.startsWith('/') ? href.slice(1) : href)}</span>
         {children}
         {ctaIcon && <SvgIcon className={icon()} icon={ctaIcon} size="xs" />}
         {(target === '_blank' || srOnlyText) && (


### PR DESCRIPTION
Adding a few rendering conditions when the text or URL is empty to avoid rendering empty text buttons and fix a Sitecore issue.

## What does this PR do and why?

<!--
Describe in detail what your pull request does and why.

Please keep this description updated with any discussion that takes place so
that reviewers can understand your intent. Keeping the description updated is
especially important if they didn't participate in the discussion.
-->
FIS-400: Updating the LinkWrapper component to include a few additional conditions when the text or URL is empty.

/*
     *
     * #1 | Link Text: Yes, Path URL: Yes (Link text and URL are defined)
     * Expected Results: CTA should be visible on the front-end page
     *
     * #2 | Link Text: Yes, Path URL: No (Link text is defined, URL is empty)
     * Expected Results: CTA should not be visible on the front-end page
     * When the link is empty and the URL is set External, the href value is 'http://' (a Sitecore bug)
     * (text && (!href || href === 'http://' || href === 'https://'))
     *
     * #3 | Link Text: No, Path URL: Yes (Internal link) (Link text is empty, URL is an internal link or a Sitecore item)
     * Expected Results: CTA should display the Path text in the front-end
     * Updated the title={title || text || href} and <span>{text || href}</span>
     *
     * #4 | Link Text: No, Path URL: Yes (External link) (Link text is empty, URL is an external link)
     * Expected Results: CTA should display the Path text in the front-end without '/'
     * Updated the <span>{text || (href?.startsWith('/') ? href.slice(1) : href)}</span>
     *
     * #5 | Link Text: Not, Path: Not (Link text is empty and URL is empty)
     * Expected Results: CTA should not be visible on the front-end page
     * if (!anchor && !href && !text) return <></>;
     *
     */

Code changes:    

Before:
    `if (!anchor && !href && !text) return <></>;`

After:
   ```
if (
      (!anchor && !href && !text) ||
      (text && (!href || href === 'http://' || href === 'https://')) // (a Sitecore bug when the External link is empty)
    ) {
      return <></>;
    }
```

Before:
    `title={title || text}`

After:
    `title={title || text || href}`
    
Before:
   `{text && <span>{text}</span>}`

After:
    `<span>{text || (href?.startsWith('/') ? href.slice(1) : href)}</span>`

## Screenshots or screen recordings
![Screenshot 2024-10-09 at 9 11 16 AM](https://github.com/user-attachments/assets/5227caaa-e06f-48c5-8c64-ff1050c2c5a8)
![Screenshot 2024-10-09 at 9 15 30 AM](https://github.com/user-attachments/assets/d867d616-cf9b-4813-b441-7b9c9d692080)
![image-2024-09-30-12-34-25-432](https://github.com/user-attachments/assets/fdc6e23f-3700-4f82-92bc-f8456885400e)

_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<!--
Please include any relevant screenshots or screen recordings that will assist
reviewers and future readers. If you need help visually verifying the change,
please leave a comment and ping a GitLab reviewer, maintainer, or MR coach.
-->

| Before | After |
| ------ | ----- |
|        |       |

## How to set up and validate locally

_Numbered steps to set up and validate the change are strongly suggested._

<!--
Example below:

1. In rails console enable the experiment fully
   ```ruby
   Feature.enable(:member_areas_of_focus)
   ```
1. Visit any group or project member pages such as `http://127.0.0.1:3000/groups/flightjs/-/group_members`
1. Click the `invite members` button.
-->

## PR acceptance checklist

This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://docs.gitlab.com/ee/development/code_review.html#acceptance-checklist) for this PR.

<!-- template sourced from https://gitlab.com/gitlab-org/gitlab/-/blob/master/.gitlab/merge_request_templates/Default.md -->
