### PR TITLE
FIS-401: Hero aligment fix for desktop and mobile

### DIFF
--- a/src/hztl-foundation/src/components/authorable/shared/hztl-page-content/Hero.tsx
+++ b/src/hztl-foundation/src/components/authorable/shared/hztl-page-content/Hero.tsx
@@ -17,28 +17,14 @@ import RichTextWrapper from 'helpers/SitecoreWrappers/RichTextWrapper/RichTextWr
 
 const TAILWIND_VARIANTS = tv({
   slots: {
-    base: [
-      'component',
-      'flex',
-      'flex-col-reverse',
-      'items-center',
-      'justify-center',
-      'md:flex-row',
-    ],
+    base: ['component', 'flex', 'flex-col-reverse', 'items-center', 'md:flex-row'],
     ctaPrimary: ['px-8'],
     ctaSecondary: ['px-8'],
     ctaLink: ['text-theme-darkblue', 'text-base'],
-    columnA: ['flex', 'items-center', 'justify-center', 'w-full', 'md:w-1/2'],
+    columnA: ['flex', 'w-full', 'md:w-1/2'],
     columnB: ['w-full', 'md:w-1/2'],
-    contentContainer: ['max-w-[472px]', 'p-6', 'w-fit'],
-    ctaContainer: [
-      'flex',
-      'flex-wrap',
-      'gap-6',
-      'justify-center',
-      'items-center',
-      'md:justify-normal',
-    ],
+    contentContainer: ['max-w-[472px]', 'p-4', 'w-full'],
+    ctaContainer: ['flex', 'flex-wrap', 'gap-6', 'md:justify-normal'],
     description: ['mb-6', 'text-base'],
     heading: ['font-bold', 'font-modern', 'mb-6', 'text-5xl', 'md:text-4xl'],
   },


### PR DESCRIPTION
https://horizontal.atlassian.net/browse/FIS-401

In Hero content area is set to justify center and should not be center. Everything should be left align by default. Also i made sure on mobile the content area spacing is consistent with the other content on the page.
![Screenshot 2024-10-11 at 1 49 25 PM](https://github.com/user-attachments/assets/36145668-f90b-4c04-9ea8-ef9318ffe725)
![Screenshot 2024-10-11 at 1 36 57 PM](https://github.com/user-attachments/assets/9286d968-ba6e-4ad8-bf9c-f3a0d1886d0e)
